### PR TITLE
Makes the use of the font-face simpler

### DIFF
--- a/.test.less
+++ b/.test.less
@@ -28,11 +28,9 @@ css3 {
   .filter(grayscale(50%), blur(1px));
 
   // TODO: test eot argument support
-  @fonts: "/fonts/";
-  @main-font-name: "Open Sans";
-  .font-face(@main-font-name, @fonts, "open-sans-regular");
-  .font-face(@main-font-name, @fonts, "open-sans-bold", 700);
-  .font-face(@main-font-name, @fonts, "open-sans-italic", 400, italic);
+  .font-face('FooFont', url('fonts/foo.otf'));
+  .font-face('FooBoldFont', url('fonts/fooBold.otf'), bold);
+  .font-face('FooItalicFont', url('fonts/fooItalic.otf'), normal, italic);
 
   // TODO: there must be testing of mixins from "images" framework
   .linear-gradient(top left, red, green);
@@ -67,6 +65,14 @@ css3 {
   .transition-duration(1s);
   .transition-timing-function(linear);
   .transition-delay(1s);
+
+  .e-calc(width, "100% - 1em");
+
+  @fonts: "/fonts/";
+  @main-font-name: "Open Sans";
+  .e-bulletproof-font-face(@main-font-name, @fonts, "open-sans-regular");
+  .e-bulletproof-font-face(@main-font-name, @fonts, "open-sans-bold", 700);
+  .e-bulletproof-font-face(@main-font-name, @fonts, "open-sans-italic", 400, italic);
 }
 
 

--- a/css3.less
+++ b/css3.less
@@ -111,14 +111,11 @@
 //
 // Font-face
 //
-.font-face(@name, @path-fonts, @file-name, @weight: 400, @style: normal, @version: "1.0") {
+.font-face(@name, @font-files, @weight: normal, @style: normal) {
   @font-face {
+    src: @font-files;
+
     font-family: @name;
-    src: url("@{path-fonts}@{file-name}.eot?v=@{version}");
-    src: url("@{path-fonts}@{file-name}.eot?#iefix&v=@{version}") format("embedded-opentype"),
-         url("@{path-fonts}@{file-name}.woff?v=@{version}") format("woff"),
-         url("@{path-fonts}@{file-name}.ttf?v=@{version}") format("truetype"),
-         url("@{path-fonts}@{file-name}.svg?v=@{version}#@{file-name}") format("svg");
     font-weight: @weight;
     font-style: @style;
   }
@@ -257,4 +254,31 @@
   -moz-transition-delay: @delay;
   -o-transition-delay: @delay;
   transition-delay: @delay;
+}
+
+
+//
+// Calc (an extension)
+//
+.e-calc(@property, @value) {
+  @{property}: -webkit-calc(@value);
+  @{property}: -moz-calc(@value);
+  @{property}: calc(@value);
+}
+
+
+//
+// Bulletproof Font-face (an extension)
+//
+.e-bulletproof-font-face(@name, @path-fonts, @file-name, @weight: 400, @style: normal, @version: "1.0") {
+  @font-face {
+    font-family: @name;
+    src: url("@{path-fonts}@{file-name}.eot?v=@{version}");
+    src: url("@{path-fonts}@{file-name}.eot?#iefix&v=@{version}") format("embedded-opentype"),
+         url("@{path-fonts}@{file-name}.woff?v=@{version}") format("woff"),
+         url("@{path-fonts}@{file-name}.ttf?v=@{version}") format("truetype"),
+         url("@{path-fonts}@{file-name}.svg?v=@{version}#@{file-name}") format("svg");
+    font-weight: @weight;
+    font-style: @style;
+  }
 }


### PR DESCRIPTION
With this implementation you have the bulletproof font code, and you only need to give parameters, not the complete src.

```
@fonts: "/fonts/";
@main-font-name: "Open Sans";

.font-face(@main-font-name, @fonts, "open-sans-regular");
.font-face(@main-font-name, @fonts, "open-sans-bold", 700);
.font-face(@main-font-name, @fonts, "open-sans-italic", 400, italic);
```
