### PR TITLE
Moved ".prefix" declaration to new file (makes all files stand-alone)

### DIFF
--- a/all.less
+++ b/all.less
@@ -1,20 +1,3 @@
-@prefixes: webkit moz ms o;
-
-.prefix(@property, @value) {
-  .prefix(@property, @value, @prefixes);
-}
-
-.prefix(@property, @value, @prefixes) {
-  .prefix(@property, @value, @prefixes, 1);
-  @{property}: @value;
-}
-
-.prefix(@property, @value, @prefixes, @index) when (@index > 0) and (length(@prefixes) >= @index) {
-  @prefix: extract(@prefixes, @index);
-  -@{prefix}-@{property}: @value;
-  .prefix(@property, @value, @prefixes, @index + 1);
-}
-
 @import "css3";
 @import "reset";
 @import "utilites";

--- a/css3.less
+++ b/css3.less
@@ -1,3 +1,5 @@
+@import "prefix";
+
 //
 // Appearance
 //

--- a/prefix.less
+++ b/prefix.less
@@ -1,0 +1,16 @@
+@prefixes: webkit moz ms o;
+
+.prefix(@property, @value) {
+  .prefix(@property, @value, @prefixes);
+}
+
+.prefix(@property, @value, @prefixes) {
+  .prefix(@property, @value, @prefixes, 1);
+  @{property}: @value;
+}
+
+.prefix(@property, @value, @prefixes, @index) when (@index > 0) and (length(@prefixes) >= @index) {
+  @prefix: extract(@prefixes, @index);
+  -@{prefix}-@{property}: @value;
+  .prefix(@property, @value, @prefixes, @index + 1);
+}

--- a/typography.less
+++ b/typography.less
@@ -1,3 +1,5 @@
+@import "prefix";
+
 //
 // Links
 //


### PR DESCRIPTION
I noticed that the individual files were not stand-alone, since "all.less" contains vital definitions of the .prefix mixins. So 

@import "compless/css3.less" 

was not working. Instead, one always had to import "compless/all.less".

I moved the .prefix mixin to its own file, to fix this.